### PR TITLE
Better error messages for keys that contain special characters

### DIFF
--- a/artifacts/bedrock_lambda/query_lambda/query_rag_bedrock.py
+++ b/artifacts/bedrock_lambda/query_lambda/query_rag_bedrock.py
@@ -31,7 +31,6 @@ service = 'aoss'
 region = getenv("REGION", "us-east-1")
 awsauth = AWS4Auth(credentials.access_key, credentials.secret_key,
                    region, service, session_token=credentials.token)
-SECRET_API_KEY = getenv("SECRET_KEY", "random_key")
 
 DEFAULT_PROMPT = """You are a helpful, respectful and honest assistant.
                     Always answer as helpfully as possible, while being safe.

--- a/creator.sh
+++ b/creator.sh
@@ -127,13 +127,19 @@ then
     printf  "$Red !!! Attention The $opt model will be deployed on $instance_type . Check Service Quotas to apply for limit increase $NC"
     
 else
-    printf "$Green Enter a custom secret API Key(atleast 20 Characters long) to secure access to Bedrock APIs $NC"
+    printf "$Green Enter a custom secret API Key(atleast 20 Characters long) to secure access to Bedrock APIs. Secret can contain (alphabets, numbers and hyphens) $NC"
     read secret_api_key
     secret_len=${#secret_api_key}
 
     if [ $secret_len -lt 20 ]
     then
         printf "$Red Secret Cannot be less than 20 characters. \n Exit \n $NC"
+        exit
+    fi
+
+    if ! [[ $secret_api_key =~ ^[a-zA-Z0-9-]+$ ]]
+    then
+        printf "$Red Secret can contain only words/digits or hyphens example: bedrock-sample-demo-access. \n Exiting setup \n $NC"
         exit
     fi
 

--- a/infrastructure/api_gw_stack.py
+++ b/infrastructure/api_gw_stack.py
@@ -175,7 +175,6 @@ class ApiGw_Stack(Stack):
                                                 'OPENSEARCH_VECTOR_ENDPOINT': collection_endpoint,
                                                 'OPENSEARCH_CHAT_ENDPOINT': chat_collection_endpoint,
                                                 'REGION': region,
-                                                'SECRET_KEY': secret_api_key,
                                                 'REST_ENDPOINT_URL': rest_endpoint_url
                                   },
                                   memory_size=2048,


### PR DESCRIPTION
Special chars in api keys breaks the HTTP basic auth process. Hence we are only allowing words/digits and hyphens during deployment

*Issue #, if available:*

*Description of changes:*
Special chars in api keys breaks the HTTP basic auth process. Hence we are only allowing words/digits and hyphens during deployment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
