### PR TITLE
Update api_gw_stack.py

### DIFF
--- a/infrastructure/api_gw_stack.py
+++ b/infrastructure/api_gw_stack.py
@@ -148,9 +148,10 @@ class ApiGw_Stack(Stack):
             
             langchainpy_layer = _lambda.LayerVersion.from_layer_version_arn(self, f'langchain-layer-{env_name}',
                                                        f'arn:aws:lambda:{region}:{account_id}:layer:{env_params["langchainpy_layer_name"]}:1')
-            
+
+            # See: https://aws-sdk-pandas.readthedocs.io/en/2.16.1/layers.html
             wrangler_layer = _lambda.LayerVersion.from_layer_version_arn(self, f'wrangler-layer-{env_name}',
-                                                       f'arn:aws:lambda:{region}:336392948345:layer:AWSDataWrangler-Python39:3')
+                                                       f'arn:aws:lambda:{region}:336392948345:layer:AWSDataWrangler-Python39:9')
             
             print('--- Amazon Bedrock Deployment ---')
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

At time of writing, when pulling the latest from `main` and running in `us-east-1` you receive the following error - note it appears as an auth error, but it's really a Layer version not found/available error:
```
User: arn:aws:sts::<ACCOUNT>:assumed-role/cdk-hnb659fds-cfn-exec-role-<ACCOUNT>-us-east-1/AWSCloudFormation is not authorized to perform: lambda:GetLayerVersion on resource: arn:aws:lambda:us-east-1:336392948345:layer:AWSDataWrangler-Python39:3 because no resource-based policy allows the lambda:GetLayerVersion action (Service: Lambda, Status Code: 403, Request ID: e3ba4d96-9898-419b-afa8-e9fc90ad25c6)
```

This fixes the `AWSDataWrangler-Python39` Lambda layer version to `:9` for `us-east-1`. Note, this PR _technically_ only fixes the issue when using `us-east-1` as other regions have different version numbers. Notice the different versions by region [here](https://aws-sdk-pandas.readthedocs.io/en/2.16.1/layers.html).