### PR TITLE
Fixed minor bug in query_rag_bedrock.py

### DIFF
--- a/artifacts/bedrock_lambda/query_lambda/query_rag_bedrock.py
+++ b/artifacts/bedrock_lambda/query_lambda/query_rag_bedrock.py
@@ -510,10 +510,11 @@ def handler(event, context):
         if routeKey != '$connect':
             if 'body' in event:
                 input_to_llm = json.loads(event['body'], strict=False)
+                print('input_to_llm: ', input_to_llm)
                 query = input_to_llm['query']
                 behaviour = input_to_llm['behaviour']
                 if 'agent' not in behaviour:
-                    query_vectordb = input_to_llm['query_vectordb']
+                    query_vectordb = input_to_llm['query_vectordb'] if 'query_vectordb' in input_to_llm else 'no'
                     model_id = input_to_llm['model_id']
                     query_data(query, behaviour, model_id, query_vectordb, connect_id)
                 else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed a minor bug in `query_rag_bedrock.py` - the `query_vectordb` may not be available in the `input_to_llm` dict. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
