### PR TITLE
[FIX] reduce Lambda MemorySize to resolve constraint error

### DIFF
--- a/infrastructure/api_gw_stack.py
+++ b/infrastructure/api_gw_stack.py
@@ -191,7 +191,7 @@ class ApiGw_Stack(Stack):
                                             'IS_BEDROCK_KB': 'no',
                                             'CONVERSATIONS_DYNAMO_TABLE_NAME': env_params['conversations_dynamo_table_name']
                               },
-                              memory_size=4096,
+                              memory_size=3000,
                               layers= [addtional_libs_layer, agentic_libs_layer_name, langchainpy_layer, pdfpy_layer]
                             )
         


### PR DESCRIPTION
**Issue** #123 

**Description of changes:**
- Updated 'memory_size' from 4096 to 3000 in the bedrock_querying_lambda_function
- Resolved the constraint error: `MemorySize' value failed to satisfy constraint: Member must have value less than or equal to 3008 (Service: Lambda, Status Code: 400)`

AWS Lambda's memory allocation can typically be configured between 128MB and 10,240MB. However, in certain regions or accounts, the memory limit may be restricted to 3008MB.

**Additional context:**
To simplify the deployment process using the script (sh creator.sh), the memory size was directly modified to 3000MB in the Python code to bypass this limitation.
If necessary, the memory size can be adjusted from 3000MB to 4096MB in the configuration of the deployed Lambda function.