### PR TITLE
feat: v2 nextgen redesign — deploy fixes, UI cleanup, sync status

### DIFF
--- a/artifacts/chat-ui/src/common/document-service.ts
+++ b/artifacts/chat-ui/src/common/document-service.ts
@@ -5,7 +5,7 @@
 
 import { S3Client, ListObjectsV2Command, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { BedrockAgentClient, StartIngestionJobCommand } from "@aws-sdk/client-bedrock-agent";
+import { BedrockAgentClient, StartIngestionJobCommand, ListIngestionJobsCommand } from "@aws-sdk/client-bedrock-agent";
 import { getRuntimeConfig } from "../runtime-config";
 import { getAwsCredentials } from "./agentcore-ws";
 
@@ -176,6 +176,51 @@ export async function getDownloadPresignedUrl(
     });
 
     return getSignedUrl(s3, command, { expiresIn: 300 });
+}
+
+export interface IngestionStatus {
+    status: string; // STARTING | IN_PROGRESS | COMPLETE | FAILED | STOPPING | STOPPED
+    startedAt?: Date;
+    updatedAt?: Date;
+    documentsScanned?: number;
+    documentsIndexed?: number;
+    documentsFailed?: number;
+}
+
+/**
+ * Get the latest ingestion job status for the KB.
+ */
+export async function getIngestionStatus(idToken: string): Promise<IngestionStatus | null> {
+    const config = getRuntimeConfig();
+    const credentials = await getAwsCredentials(idToken);
+
+    const client = new BedrockAgentClient({
+        region: config.cognitoRegion,
+        credentials: {
+            accessKeyId: credentials.accessKeyId,
+            secretAccessKey: credentials.secretAccessKey,
+            sessionToken: credentials.sessionToken,
+        },
+    });
+
+    const response = await client.send(new ListIngestionJobsCommand({
+        knowledgeBaseId: config.knowledgeBaseId,
+        dataSourceId: config.dataSourceId,
+        maxResults: 1,
+        sortBy: { attribute: "STARTED_AT", order: "DESCENDING" },
+    }));
+
+    const job = response.ingestionJobSummaries?.[0];
+    if (!job) return null;
+
+    return {
+        status: job.status || "Unknown",
+        startedAt: job.startedAt,
+        updatedAt: job.updatedAt,
+        documentsScanned: job.statistics?.numberOfDocumentsScanned,
+        documentsIndexed: job.statistics?.numberOfNewDocumentsIndexed,
+        documentsFailed: job.statistics?.numberOfDocumentsFailed,
+    };
 }
 
 /**

--- a/artifacts/chat-ui/src/common/evaluation-service.ts
+++ b/artifacts/chat-ui/src/common/evaluation-service.ts
@@ -154,7 +154,7 @@ export async function createEvalJob(
                             type: "KNOWLEDGE_BASE",
                             knowledgeBaseConfiguration: {
                                 knowledgeBaseId: config.knowledgeBaseId,
-                                modelArn: `arn:aws:bedrock:${config.cognitoRegion}::foundation-model/anthropic.claude-sonnet-4-6-v1:0`,
+                                modelArn: "global.anthropic.claude-sonnet-4-6",
                             },
                         },
                     },
@@ -166,7 +166,7 @@ export async function createEvalJob(
         },
     }));
 
-    return response.jobIdentifier!;
+    return response.jobArn || response.jobIdentifier || "";
 }
 
 /**

--- a/artifacts/chat-ui/src/common/evaluation-service.ts
+++ b/artifacts/chat-ui/src/common/evaluation-service.ts
@@ -99,7 +99,9 @@ export async function uploadEvalDataset(
         return JSON.stringify(entry);
     }).join("\n");
 
-    const key = `evaluations/${userEmail}/${jobId}/input.jsonl`;
+    // Sanitize email for S3 path — Bedrock URI regex only allows [-!_*'().a-z0-9A-Z]
+    const safeEmail = userEmail.replace(/[^-!_*'().a-z0-9A-Z]/g, "_");
+    const key = `evaluations/${safeEmail}/${jobId}/input.jsonl`;
     await s3.send(new PutObjectCommand({
         Bucket: config.dataBucketName,
         Key: key,
@@ -219,7 +221,8 @@ export async function getEvalResults(
     const credentials = await getAwsCredentials(idToken);
     const s3 = getS3Client(credentials);
 
-    const key = `evaluations/${userEmail}/${jobId}/output/results.jsonl`;
+    const safeEmail = userEmail.replace(/[^-!_*'().a-z0-9A-Z]/g, "_");
+    const key = `evaluations/${safeEmail}/${jobId}/output/results.jsonl`;
 
     try {
         const response = await s3.send(new GetObjectCommand({

--- a/artifacts/chat-ui/src/components/eval-ui/eval-input.tsx
+++ b/artifacts/chat-ui/src/components/eval-ui/eval-input.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import {
     Box, Button, Checkbox, Container, FileUpload, FormField,
-    Header, SpaceBetween, Tabs, Textarea, Toggle,
+    Header, Icon, Link, SpaceBetween, Tabs, Textarea, Toggle,
 } from "@cloudscape-design/components";
 import { ALL_METRICS, DEFAULT_METRICS, EvalQuestion } from "../../common/evaluation-service";
 
@@ -58,7 +58,7 @@ export function EvalInput({ onStartEvaluation, isRunning }: EvalInputProps) {
     };
 
     return (
-        <Container header={<Header variant="h2" info={<a href="#/evaluation">Help</a>}>Configure Evaluation</Header>}>
+        <Container header={<Header variant="h2" info={<Link href="#/evaluation" variant="info"><Icon name="status-info" /></Link>}>Configure Evaluation</Header>}>
             <SpaceBetween size="l">
                 <Toggle
                     checked={isGroundTruth}

--- a/artifacts/chat-ui/src/components/eval-ui/eval-input.tsx
+++ b/artifacts/chat-ui/src/components/eval-ui/eval-input.tsx
@@ -58,7 +58,7 @@ export function EvalInput({ onStartEvaluation, isRunning }: EvalInputProps) {
     };
 
     return (
-        <Container header={<Header variant="h2">Configure Evaluation</Header>}>
+        <Container header={<Header variant="h2" info={<a href="#/evaluation">Help</a>}>Configure Evaluation</Header>}>
             <SpaceBetween size="l">
                 <Toggle
                     checked={isGroundTruth}

--- a/artifacts/chat-ui/src/components/upload-ui/upload-ui.tsx
+++ b/artifacts/chat-ui/src/components/upload-ui/upload-ui.tsx
@@ -7,7 +7,8 @@ import { LoadingBar } from "@cloudscape-design/chat-components";
 import { AppContext } from "../../common/context";
 import {
   listDocuments, getUploadPresignedUrl, uploadMetadata,
-  deleteDocument, syncKnowledgeBase, DocumentInfo
+  deleteDocument, syncKnowledgeBase, getIngestionStatus,
+  DocumentInfo, IngestionStatus
 } from "../../common/document-service";
 
 export interface UploadDocProps {
@@ -22,6 +23,7 @@ export function UploadUI(props: UploadDocProps) {
   const [userFiles, setUserFiles] = useState<DocumentInfo[]>([]);
   const [globalView, setGlobalView] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
+  const [syncStatus, setSyncStatus] = useState<IngestionStatus | null>(null);
   const PAGE_SIZE = 20;
   const appData = useContext(AppContext);
 
@@ -37,6 +39,15 @@ export function UploadUI(props: UploadDocProps) {
     props.notify_parent?.(message, notify_type);
   };
 
+  const refreshSyncStatus = async () => {
+    try {
+      const status = await getIngestionStatus(getIdToken());
+      setSyncStatus(status);
+    } catch {
+      // silently ignore - non-critical
+    }
+  };
+
   const refreshFileList = async () => {
     setIsLoading(true);
     try {
@@ -46,6 +57,7 @@ export function UploadUI(props: UploadDocProps) {
       notify(`Failed to list documents: ${err.message}`, "error");
     }
     setIsLoading(false);
+    refreshSyncStatus();
   };
 
   useEffect(() => {
@@ -53,6 +65,13 @@ export function UploadUI(props: UploadDocProps) {
       refreshFileList();
     }
   }, [appData, globalView]);
+
+  // Auto-poll sync status while in progress
+  useEffect(() => {
+    if (!syncStatus || !["STARTING", "IN_PROGRESS"].includes(syncStatus.status)) return;
+    const interval = setInterval(refreshSyncStatus, 5000);
+    return () => clearInterval(interval);
+  }, [syncStatus?.status]);
 
   const uploadFile = async () => {
     if (value.length === 0) return;
@@ -153,6 +172,27 @@ export function UploadUI(props: UploadDocProps) {
       }
     >
       {isLoading && <LoadingBar variant="gen-ai" />}
+      {syncStatus && (
+        <Box margin={{ bottom: "s" }}>
+          <StatusIndicator
+            type={
+              syncStatus.status === "COMPLETE" ? "success" :
+              syncStatus.status === "FAILED" ? "error" :
+              ["STARTING", "IN_PROGRESS"].includes(syncStatus.status) ? "in-progress" :
+              "info"
+            }
+          >
+            {syncStatus.status === "COMPLETE" && (
+              <>Last sync complete{syncStatus.updatedAt ? ` — ${syncStatus.updatedAt.toLocaleString()}` : ""}{syncStatus.documentsIndexed != null ? ` (${syncStatus.documentsIndexed} indexed${syncStatus.documentsFailed ? `, ${syncStatus.documentsFailed} failed` : ""})` : ""}</>
+            )}
+            {syncStatus.status === "FAILED" && "Last sync failed"}
+            {["STARTING", "IN_PROGRESS"].includes(syncStatus.status) && (
+              <>Sync in progress...{syncStatus.documentsScanned != null ? ` (${syncStatus.documentsScanned} scanned)` : ""}</>
+            )}
+            {!["COMPLETE", "FAILED", "STARTING", "IN_PROGRESS"].includes(syncStatus.status) && `Sync: ${syncStatus.status}`}
+          </StatusIndicator>
+        </Box>
+      )}
       <Table
         variant="full-page"
         columnDefinitions={[

--- a/artifacts/chat-ui/src/help-properties.json
+++ b/artifacts/chat-ui/src/help-properties.json
@@ -13,7 +13,7 @@
     },
     "doc-chat-manage":{
         "title":"Manage Documents",
-        "description": "Upload PDF files, that are then vectorized and stored in <a href='https://aws.amazon.com/opensearch-service/features/serverless/'>Amazon Opensearch serverless service(AOSS)</a>. AOSS supports semantic searches which is a key requirement when building a <a href='https://aws.amazon.com/blogs/big-data/build-scalable-and-serverless-rag-workflows-with-a-vector-engine-for-amazon-opensearch-serverless-and-amazon-bedrock-claude-models/'>Retrieval Augmented Generation</a> based solution"
+        "description": "<p>Upload documents that are indexed into a <a href='https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html'>Bedrock Knowledge Base</a> backed by <a href='https://aws.amazon.com/opensearch-service/features/serverless/'>Amazon OpenSearch Serverless (NextGen)</a>.</p><h3>Sync Status</h3><p>After uploading or deleting documents, an ingestion job syncs your files to the Knowledge Base index. The status indicator above the table shows:</p><ul><li><b>Sync in progress</b> — Files are being processed (auto-refreshes every 5s)</li><li><b>Last sync complete</b> — Shows timestamp, documents indexed, and any failures</li><li><b>Last sync failed</b> — Check file formats or permissions</li></ul><p>Supported formats: PDF, TXT, MD, HTML, DOC, DOCX, CSV.</p><p><b>Tip:</b> Files become searchable in Document Chat within 1–3 minutes after sync completes.</p>"
     },
     "sentiment": {
         "title": "Sentiment Analysis",

--- a/artifacts/chat-ui/src/pages/eval-page.tsx
+++ b/artifacts/chat-ui/src/pages/eval-page.tsx
@@ -61,7 +61,8 @@ function EvalPageContent(props: AppPage) {
         try {
             const datasetUri = await uploadEvalDataset(questions, jobId, userEmail, idToken);
             const config = getRuntimeConfig();
-            const outputPrefix = `s3://${config.dataBucketName}/evaluations/${userEmail}/${jobId}/output/`;
+            const safeEmail = userEmail.replace(/[^-!_*'().a-z0-9A-Z]/g, "_");
+            const outputPrefix = `s3://${config.dataBucketName}/evaluations/${safeEmail}/${jobId}/output/`;
 
             const jobArn = await createEvalJob(jobName, datasetUri, outputPrefix, metrics, idToken);
 

--- a/artifacts/chat-ui/src/pages/home-page.tsx
+++ b/artifacts/chat-ui/src/pages/home-page.tsx
@@ -40,7 +40,7 @@ export default function HomePage() {
                   color="text-body-secondary"
                   margin={{ top: "xs", bottom: "l" }}
                 >
-                  A fully managed serverless generative AI solution for various use cases, including Retrieval Augmented Generation, Sentiment Analysis, OCR, and Multi-Agent systems.
+                  A fully managed serverless generative AI solution for Retrieval Augmented Generation and Multi-Agent systems.
                 </Box>
               </Box>
             </Container>
@@ -51,29 +51,13 @@ export default function HomePage() {
       <SpaceBetween size="xxl">
         <Box>&nbsp;</Box>
         <Container>
-          <ColumnLayout borders="vertical" columns={5}>
+          <ColumnLayout borders="vertical" columns={2}>
             <div>
               <Box padding="l" variant="h3">Document Chat</Box>
-              {/* <Box variant="p">Retrieval Augmented Generation Solution</Box> */}
             </div>
             <div>
               <Box padding="l" variant="h3">Multi Agent</Box>
-              {/* <Box variant="p">This solution comprises of multiple-generative AI agents working in tandem to solve a user-problem</Box> */}
             </div>
-            <div>
-              <Box padding="l" variant="h3">Sentiment Analysis</Box>
-              {/* <Box variant="p"></Box> */}
-            </div>
-            <div>
-              <Box padding="l" variant="h3">OCR</Box>
-              {/* <Box variant="p"></Box> */}
-            </div>
-            <div>
-              <Box padding="l" variant="h3">PII Redaction</Box>
-              {/* <Box variant="p"></Box> */}
-            </div>
-
-            
           </ColumnLayout>
         </Container>
 
@@ -133,85 +117,6 @@ export default function HomePage() {
 
 
 
-    <Container
-      media={{
-        content: (
-          <img
-            src="/images/sentiment.png"
-            alt="placeholder"
-          />
-        ),
-        position: "side",
-        width: "14%"
-      }}
-    >
-      <SpaceBetween direction="vertical" size="s">
-        <SpaceBetween direction="vertical" size="xxs">
-          <Box variant="h2">
-            <Link fontSize="heading-m" href="#/sentiment-analysis">
-              Sentiment Analysis
-            </Link>
-          </Box>
-        </SpaceBetween>
-        <Box variant="p">
-          Analyze sentiments of a customer review/tweet/Facebook post through foundation models. The model detects the emotion expressed in the review, rates the review on a scale of 1-10.
-        </Box>
-      </SpaceBetween>
-    </Container>
-
-
-
-    <Container
-      media={{
-        content: (
-          <img
-            src="/images/ocr.png"
-            alt="placeholder"
-          />
-        ),
-        position: "side",
-        width: "14%"
-      }}
-    >
-      <SpaceBetween direction="vertical" size="s">
-        <SpaceBetween direction="vertical" size="xxs">
-          <Box variant="h2">
-            <Link fontSize="heading-m" href="#/ocr">
-              OCR
-            </Link>
-          </Box>
-        </SpaceBetween>
-        <Box variant="p">
-          Perform OCR on PDFs/Images through foundation models.
-        </Box>
-      </SpaceBetween>
-    </Container>
-
-    <Container
-      media={{
-        content: (
-          <img
-            src="/images/ocr.png"
-            alt="placeholder"
-          />
-        ),
-        position: "side",
-        width: "14%"
-      }}
-    >
-      <SpaceBetween direction="vertical" size="s">
-        <SpaceBetween direction="vertical" size="xxs">
-          <Box variant="h2">
-            <Link fontSize="heading-m" href="#/pii">
-              PII Redaction
-            </Link>
-          </Box>
-        </SpaceBetween>
-        <Box variant="p">
-          Identify and Redact PII(Personally Identifiable Information) through foundation models.
-        </Box>
-      </SpaceBetween>
-    </Container>
 
 
       </SpaceBetween>

--- a/deploy.sh
+++ b/deploy.sh
@@ -103,7 +103,7 @@ EVAL_ROLE_ARN=$(jq -r ".[\"SRD-Auth-$ENV_NAME\"] | to_entries[] | select(.key | 
 
 # Get Knowledge Base values from CDK outputs
 KB_ID=$(jq -r ".[\"SRD-KB-$ENV_NAME\"] | to_entries[] | select(.key | contains(\"kbid\")) | .value" cdk-outputs.json)
-DATA_BUCKET=$(jq -r ".[\"SRD-KB-$ENV_NAME\"] | to_entries[] | select(.key | contains(\"databucket\")) | .value" cdk-outputs.json)
+DATA_BUCKET=$(jq -r ".[\"SRD-KB-$ENV_NAME\"] | to_entries[] | select(.key | startswith(\"databucket\")) | .value" cdk-outputs.json)
 DATA_SOURCE_ID=$(jq -r ".[\"SRD-KB-$ENV_NAME\"] | to_entries[] | select(.key | contains(\"datasourceid\")) | .value" cdk-outputs.json)
 
 # Get ECR image URIs from CDK outputs (CDK strips hyphens from output keys)

--- a/infrastructure/cognito_stack.py
+++ b/infrastructure/cognito_stack.py
@@ -140,7 +140,7 @@ class CognitoStack(Stack):
                 ]),
                 "KBSync": iam.PolicyDocument(statements=[
                     iam.PolicyStatement(
-                        actions=["bedrock:StartIngestionJob"],
+                        actions=["bedrock:StartIngestionJob", "bedrock:ListIngestionJobs"],
                         resources=[f"arn:aws:bedrock:{region}:{account_id}:knowledge-base/{knowledge_base_id}"],
                     ),
                 ]),

--- a/infrastructure/knowledge_base_stack.py
+++ b/infrastructure/knowledge_base_stack.py
@@ -106,6 +106,7 @@ class KnowledgeBaseStack(Stack):
                 type="S3",
                 s3_configuration=bedrock.CfnDataSource.S3DataSourceConfigurationProperty(
                     bucket_arn=data_bucket.bucket_arn,
+                    inclusion_prefixes=["documents/"],
                 ),
             ),
         )

--- a/tests/e2e/sample-eval-dataset.json
+++ b/tests/e2e/sample-eval-dataset.json
@@ -1,0 +1,6 @@
+[
+  {
+    "question": "What are the new tax reforms?",
+    "expected_answer": "The Australian Government announced several key tax reforms: 1) Working Australians Tax Offset (WATO) - a $250 permanent annual tax offset for every working Australian taxpayer from 1 July 2027, benefiting over 13 million workers and increasing the effective tax-free threshold by nearly $1,800 to $19,985. 2) $1,000 Instant Tax Deduction for work-related expenses. 3) Negative Gearing & CGT Reform from 1 July 2027 - limiting negative gearing for residential property to new builds only, replacing the 50% CGT discount with cost base indexation and a 30% minimum tax rate on capital gains. 4) Medicare Levy Low-Income Thresholds increased by 2.9% for singles, families, seniors and pensioners from 1 July 2025. A worker on average earnings would receive a combined benefit of up to $2,816 from the 2027-28 income year."
+  }
+]


### PR DESCRIPTION
## Summary
- Fix deploy.sh jq selectors to match CDK's hyphen-stripped output keys
- Remove Sentiment Analysis, OCR, and PII from home page (v2 scope: Document Chat + Multi-Agent only)
- Add KB ingestion sync status indicator to Manage Documents page with auto-polling
- Add `ListIngestionJobs` IAM permission to Cognito authenticated role
- Add sample evaluation dataset for testing

## Test plan
- [x] Deployed to CloudFront (https://d1jyrvgdj3trhw.cloudfront.net)
- [x] Verified sync status indicator appears after sign-in
- [x] Confirmed ListIngestionJobs permission works after re-auth
- [ ] Upload a new document and verify status transitions from "in progress" to "complete"

🤖 Generated with [Claude Code](https://claude.com/claude-code)