### PR TITLE
fix: use underscore in agent runtime endpoint name

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -150,7 +150,7 @@ deploy_runtime() {
         RUNTIME_ID=$(echo "$RUNTIME_ARN" | awk -F/ '{print $NF}')
         aws bedrock-agentcore-control create-agent-runtime-endpoint \
             --agent-runtime-id "$RUNTIME_ID" \
-            --name "${RUNTIME_NAME}-endpoint" \
+            --name "${RUNTIME_NAME}_endpoint" \
             --region "$REGION" > /dev/null
         echo "      Endpoint created" >&2
     else


### PR DESCRIPTION
## Summary
- Fixes invalid character in agent runtime endpoint name by replacing hyphen with underscore separator (`${RUNTIME_NAME}-endpoint` → `${RUNTIME_NAME}_endpoint`)

## Test plan
- [ ] Deploy and verify agent runtime endpoint is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)