### PR TITLE
feat: add Amazon Nova 2 Lite model for document chat

### DIFF
--- a/artifacts/chat-ui/src/components/chat-ui/chat-ui-input-panel.tsx
+++ b/artifacts/chat-ui/src/components/chat-ui/chat-ui-input-panel.tsx
@@ -22,6 +22,7 @@ export interface ChatUIInputPanelProps {
   sendButtonText?: string;
   running?: boolean;
   messages?: ChatMessage[];
+  selected_model_option?: string;
   check_vector_db?: boolean;
   is_hybrid_search?: boolean;
   clear_socket?: boolean;
@@ -106,6 +107,7 @@ export default function ChatUIInputPanel(props: ChatUIInputPanelProps) {
       const searchType = props.is_hybrid_search ? "HYBRID" : "SEMANTIC";
       ws!.send(JSON.stringify({
         query,
+        model_id: props.selected_model_option,
         search_scope: searchScope,
         search_type: searchType,
         chat_history: chatHistory.slice(-10),

--- a/artifacts/chat-ui/src/default-properties.json
+++ b/artifacts/chat-ui/src/default-properties.json
@@ -33,6 +33,14 @@
                     "description": "Most capable | US-only routing | Up to 200k context",
                     "tags": ["Anthropic"],
                     "labelTag": "US Region"
+                },
+                {
+                    "label": "Nova 2 Lite (Global)",
+                    "value": "global.amazon.nova-2-lite-v1:0",
+                    "iconName": "keyboard",
+                    "description": "Fast & cost-effective | Global routing | Up to 300k context",
+                    "tags": ["Amazon"],
+                    "labelTag": "Cost Optimized"
                 }
             ],
             "languages": [

--- a/containers/rag-query/app.py
+++ b/containers/rag-query/app.py
@@ -19,6 +19,7 @@ async def websocket_handler(websocket, context):
         while True:
             data = await websocket.receive_json()
             query = data.get("query", "")
+            model_id = data.get("model_id")
             user_email = data.get("user_email")
             search_scope = data.get("search_scope", "all")
             search_type = data.get("search_type", "HYBRID")
@@ -34,6 +35,7 @@ async def websocket_handler(websocket, context):
             try:
                 async for chunk in rag_query_stream(
                     query=query,
+                    model_id=model_id,
                     user_email=user_email,
                     search_scope=search_scope,
                     search_type=search_type,

--- a/containers/rag-query/query.py
+++ b/containers/rag-query/query.py
@@ -11,8 +11,9 @@ MODEL_ID = os.getenv("MODEL_ID", "global.anthropic.claude-sonnet-4-6")
 bedrock_agent_runtime = boto3.client("bedrock-agent-runtime", region_name=REGION)
 
 
-async def rag_query_stream(query: str, user_email: str = None, search_scope: str = "all", search_type: str = "HYBRID", chat_history: list = None):
+async def rag_query_stream(query: str, model_id: str = None, user_email: str = None, search_scope: str = "all", search_type: str = "HYBRID", chat_history: list = None):
     """Stream RAG query response with native citations via retrieve_and_generate_stream."""
+    model_id = model_id or MODEL_ID
 
     # Build retrieval filter for per-user search
     filter_config = None
@@ -24,7 +25,7 @@ async def rag_query_stream(query: str, user_email: str = None, search_scope: str
     retrieval_config = {
         "knowledgeBaseConfiguration": {
             "knowledgeBaseId": KB_ID,
-            "modelArn": f"arn:aws:bedrock:{REGION}::foundation-model/{MODEL_ID}" if not MODEL_ID.startswith("arn:") else MODEL_ID,
+            "modelArn": f"arn:aws:bedrock:{REGION}::foundation-model/{model_id}" if not model_id.startswith("arn:") else model_id,
             "retrievalConfiguration": {
                 "vectorSearchConfiguration": {
                     "numberOfResults": 5,
@@ -52,7 +53,7 @@ async def rag_query_stream(query: str, user_email: str = None, search_scope: str
         query = f"Context from recent conversation:\n{history_text}\n\nCurrent question: {query}"
 
     # Use model ARN for retrieve_and_generate_stream
-    model_arn = MODEL_ID
+    model_arn = model_id
     if not model_arn.startswith("arn:"):
         # For global inference profiles
         if model_arn.startswith("global."):
@@ -73,7 +74,7 @@ async def rag_query_stream(query: str, user_email: str = None, search_scope: str
     except Exception as e:
         logger.error(f"retrieve_and_generate_stream failed: {e}")
         # Fallback to separate retrieve + converse if streaming RAG not available
-        async for chunk in _fallback_rag_stream(query, user_email, search_scope, search_type, chat_history):
+        async for chunk in _fallback_rag_stream(query, model_id, user_email, search_scope, search_type, chat_history):
             yield chunk
         return
 
@@ -106,8 +107,9 @@ async def rag_query_stream(query: str, user_email: str = None, search_scope: str
                     citations_sent = True
 
 
-async def _fallback_rag_stream(query: str, user_email: str = None, search_scope: str = "all", search_type: str = "HYBRID", chat_history: list = None):
+async def _fallback_rag_stream(query: str, model_id: str = None, user_email: str = None, search_scope: str = "all", search_type: str = "HYBRID", chat_history: list = None):
     """Fallback: separate Retrieve + ConverseStream if retrieve_and_generate_stream unavailable."""
+    model_id = model_id or MODEL_ID
     bedrock_runtime = boto3.client("bedrock-runtime", region_name=REGION)
 
     retrieval_config = {
@@ -160,7 +162,7 @@ Retrieved Context:
 {context}"""
 
     response = bedrock_runtime.converse_stream(
-        modelId=MODEL_ID,
+        modelId=model_id,
         messages=[{"role": "user", "content": [{"text": query}]}],
         system=[{"text": system_prompt}],
         inferenceConfig={"maxTokens": 4096},

--- a/infrastructure/agentcore_stack.py
+++ b/infrastructure/agentcore_stack.py
@@ -67,6 +67,7 @@ class AgentCoreStack(Stack):
                         resources=[
                             f"arn:aws:bedrock:{region}:{account_id}:inference-profile/*",
                             f"arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
+                            f"arn:aws:bedrock:*::foundation-model/amazon.nova-*",
                         ],
                     ),
                     iam.PolicyStatement(
@@ -96,6 +97,7 @@ class AgentCoreStack(Stack):
                         resources=[
                             f"arn:aws:bedrock:{region}:{account_id}:inference-profile/*",
                             f"arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
+                            f"arn:aws:bedrock:*::foundation-model/amazon.nova-*",
                         ],
                     ),
                     iam.PolicyStatement(


### PR DESCRIPTION
## Summary
- Adds `global.amazon.nova-2-lite-v1:0` as a selectable model in the Document Chat UI
- Wires the UI model selection through WebSocket to the backend (previously the model was hardcoded via env var)
- Adds `amazon.nova-*` to IAM resource ARNs in both multi-agent and RAG query roles

## Changes
| File | Change |
|------|--------|
| `default-properties.json` | New model entry with "Cost Optimized" label |
| `chat-ui-input-panel.tsx` | Send `model_id` in WebSocket payload + add to props interface |
| `agentcore_stack.py` | Add `amazon.nova-*` foundation model ARN to both IAM policies |
| `containers/rag-query/app.py` | Extract `model_id` from WebSocket message and pass to query |
| `containers/rag-query/query.py` | Accept `model_id` param, use it instead of global `MODEL_ID` constant |

## Test plan
- [ ] Verify UI shows "Nova 2 Lite (Global)" in model dropdown
- [ ] Select Nova 2 Lite and send a document chat query
- [ ] Verify response streams back successfully
- [ ] Verify existing Claude models still work (backward compatible — falls back to env var default when no model_id sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)